### PR TITLE
Change running UnitTest in Single Activity

### DIFF
--- a/AzureAutomaticGradingEngineFunctionApp/Model/Entities.cs
+++ b/AzureAutomaticGradingEngineFunctionApp/Model/Entities.cs
@@ -22,4 +22,19 @@ namespace AzureAutomaticGradingEngineFunctionApp.Model
         public string Subject { get; set; }
         public string Body { get; set; }
     }
+
+    public class ClassGradingJob
+    {
+        public Assignment assignment { get; set; }
+        public string graderUrl { get; set; }
+        public dynamic students { get; set; }
+    }
+
+    public class SingleGradingJob
+    {
+        public Assignment assignment { get; set; }
+        public string graderUrl { get; set; }
+        public dynamic student { get; set; }
+    }
+
 }

--- a/AzureAutomaticGradingEngineFunctionApp/host.json
+++ b/AzureAutomaticGradingEngineFunctionApp/host.json
@@ -8,7 +8,7 @@
       }
     }
   },
-  "functionTimeout": "00:05:00",
+  "functionTimeout": "00:10:00",
   "extensions": {
     "queues": {
       "maxPollingInterval": "00:01:00",

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Or update \repos\AzureGraderTestProject\AzureGraderTestProject\Config.cs
 
 ## Scheduler Grader
 
-The scheduler is set to runs every 5 minutes by default and you can change the TimerTrigger expression.
+The scheduler is set to runs every 12 hours by default and you can change the TimerTrigger expression.
 https://github.com/microsoft/AzureAutomaticGradingEngine/blob/master/AzureAutomaticGradingEngineFunctionApp/ScheduleGraderFunction.cs 
 
 testresult: saves Nunit xml test result.


### PR DESCRIPTION
Since there is no quick fix to enable the parallel run NUnit tests in Azure Function, to grade a class inside one activity may cause timeout happen. 
The temp fix is to run Unit test one by one and put it into single activity.