### PR TITLE
Allow students to resubmit their credentials

### DIFF
--- a/AzureAutomaticGradingEngineFunctionApp/Model/TableEntities.cs
+++ b/AzureAutomaticGradingEngineFunctionApp/Model/TableEntities.cs
@@ -16,7 +16,6 @@ namespace AzureAutomaticGradingEngineFunctionApp.Model
     {
         public string GraderUrl { get; set; }
         public string TeacherEmail { get; set; }
-
         public bool? SendMarkEmailToStudents { get; set; }
     }
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ https://somethingunique.azurewebsites.net/api/StudentRegistrationFunction?projec
 <code>az account show</code>
 6.	Create SDK Auth, keep it privately and don't run this command again
 <code>az ad sp create-for-rbac -n "gradingengine" --sdk-auth</code>
-7.	Submit online registration form
+7.	Submit the online registration form.
+https://XXXXXX.azurewebsites.net/api/StudentRegistrationFunction?project=AssignmentName&email=abcd@stu.vtc.edu.hk
 
 Note: 
-1. Subscription ID must be unique for each assignment.
-2. Don't run <code>az ad sp create-for-rbac -n "gradingengine" --sdk-auth</code> repeatedly! If errors occure the educator will  need to remove the students record in the subscription table and asks the student to resubmit the online form with the new credentials.
+1. Subscription ID and Email must be unique for each assignment.
+2. Don't run <code>az ad sp create-for-rbac -n "gradingengine" --sdk-auth</code> repeatedly! Students need to submit the online from again with the new credentials.
 
 ## Quick test with AzureGraderConsoleRunner
 


### PR DESCRIPTION
Too many students keep re-run the command  az ad sp create-for-rbac -n "gradingengine" --sdk-auth and request teacher to help them delete the record in subscription table and resubmit the new credentials.
So, changed the logic to check subscription ID and email to allow students update the credentials.
